### PR TITLE
Add codec information, WiFi monitoring, and generic API methods

### DIFF
--- a/pykefcontrol/__init__.py
+++ b/pykefcontrol/__init__.py
@@ -1,3 +1,3 @@
 from pykefcontrol.kef_connector import KefConnector, KefAsyncConnector
 
-__version__ = "0.7.1"
+__version__ = "0.8"

--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -145,6 +145,55 @@ class KefConnector:
             # Silently return empty dict if codec info not available
             return {}
 
+    def get_request(self, path, roles="value"):
+        """Generic method to get data from any API path.
+
+        Args:
+            path: API path to query (e.g., "kef:eqProfile", "network:info")
+            roles: API roles parameter (default: "value")
+
+        Returns:
+            JSON response from API
+        """
+        payload = {
+            "path": path,
+            "roles": roles,
+        }
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output
+
+    def get_wifi_information(self):
+        """Get WiFi information from speaker.
+
+        Returns dict with WiFi signal strength, SSID, frequency, and BSSID.
+        Returns empty dict if WiFi info is not available.
+        """
+        try:
+            # Get network info from speaker
+            network_data = self.get_request("network:info", roles="value")
+
+            wifi_dict = {}
+            network_info = (
+                network_data[0].get("networkInfo", {}) if network_data else {}
+            )
+
+            if network_info:
+                wireless = network_info.get("wireless", {})
+                if wireless:
+                    wifi_dict["signalLevel"] = wireless.get("signalLevel")
+                    wifi_dict["ssid"] = wireless.get("ssid")
+                    wifi_dict["frequency"] = wireless.get("frequency")
+                    wifi_dict["bssid"] = wireless.get("bssid")
+
+            return wifi_dict
+        except Exception:
+            # Silently return empty dict if WiFi info not available
+            return {}
+
     def _get_polling_queue(self, song_status=False, poll_song_status=False):
         """
         Get the polling queue uuid, and subscribe to all relevant topics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykefcontrol"
-version = "0.7.1"
+version = "0.8"
 description = "Python library for controling KEF speakers (LS50W2, LSX2, LS60). It supports basic commands for setting the volume, the source, and getting the media playing informations."
 authors = ["Robin Dupont <robin.dpnt@gmail.com>"]
 homepage = "https://github.com/rodupont/pykefcontrol"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name="pykefcontrol",
     packages=["pykefcontrol"],
-    version="0.7",
+    version="0.8",
     license="MIT",
     description="Python library for controling KEF speakers",
     long_description="Python library for controling KEF speakers (LS50W2, LSX2, LS60). It supports basic commands for setting the volume, the source, and getting the media playing informations",


### PR DESCRIPTION
- Add get_audio_codec_information() to retrieve codec, sample rates, and channel info
- Add get_wifi_information() to retrieve WiFi signal, SSID, frequency, and BSSID
- Add generic get_request() method for custom API queries
- Enhance get_song_information() to include service_id (e.g., airplay, spotify)
- Include serviceID in codec information from metadata
- Available in both KefConnector (sync) and KefAsyncConnector (async)

These additions provide more complete speaker information for integrations and applications using the library.
I also updated the hass-kef-connector, but once this PR is merged, I can change the code to use the newer library as well.