### PR TITLE
Add speaker settings: volume management, hardware controls, and LED controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # VScode specific
 .vscode/
+# APK decompilation working directories
+apk/

--- a/README.md
+++ b/README.md
@@ -204,110 +204,375 @@ All the possible keys of the dictionary are:
  `source`, `song_status`, `volume`, `song_info`, `song_length`, `status`, `speaker_status`, `device_name`, `mute` and `other`.
 `other` contains some of the speaker-specific information that might have changed, but are not properties of either `KefConnector` or `KefAsyncConnector`. 
 
-**Volume Management**
+### Volume Management
+
+Control per-input default volumes and volume behavior settings. Each physical input (WiFi, Bluetooth, Optical, etc.) can have its own default volume level, or you can use a global volume for all inputs.
+
+#### Per-Input Default Volumes
+
+Set different default volumes for each input source:
+
 ```python
-# Get default startup volume for a specific input source
-my_speaker.get_default_volume('wifi')
-# (output example) >>> 50
+import pykefcontrol as pkf
 
-# Set default startup volume for a specific input source
-# Supported sources: 'wifi', 'bluetooth', 'optical', 'coaxial', 'usb', 'analogue', 'tv'
-my_speaker.set_default_volume('wifi', 50)
+speaker = pkf.KefConnector('192.168.1.100')
 
-# Get default volumes for all input sources at once
-my_speaker.get_all_default_volumes()
-# (output example) >>> {'wifi': 50, 'bluetooth': 40, 'optical': 60, 'coaxial': 60, 'usb': 50, 'analogue': 60, 'tv': 50}
+# Get default volume for a specific input
+wifi_volume = speaker.get_default_volume('wifi')  # Returns 0-100
+bluetooth_volume = speaker.get_default_volume('bluetooth')
 
-# Get volume settings (max volume cap, step size, limit)
-my_speaker.get_volume_settings()
-# (output example) >>> {'max_volume': 100, 'step': 5, 'limit': 85}
+# Set default volume for specific inputs
+speaker.set_default_volume('wifi', 50)       # Set WiFi to 50%
+speaker.set_default_volume('bluetooth', 40)  # Set Bluetooth to 40%
+speaker.set_default_volume('optical', 60)    # Set Optical to 60%
 
-# Set volume settings
-my_speaker.set_volume_settings(max_volume=100, step=5, limit=85)
+# Get all default volumes at once
+all_volumes = speaker.get_all_default_volumes()
+# Returns: {'global': 30, 'wifi': 50, 'bluetooth': 40, 'optical': 60, ...}
 
-# Get/set whether standby resumes at global or per-source volume
-my_speaker.get_standby_volume_behavior()
-# (output example) >>> True  # True = use global volume, False = use per-source volume
-my_speaker.set_standby_volume_behavior(True)
-
-# Get/set startup volume override (when enabled, uses configured default volumes on wake)
-my_speaker.get_startup_volume_enabled()
-# (output example) >>> False
-my_speaker.set_startup_volume_enabled(True)
+# Print all volumes
+for source, volume in sorted(all_volumes.items()):
+    print(f"{source:12s}: {volume}%")
 ```
 
-**Hardware Settings**
+**Available input sources by model:**
+- **LSX II**: wifi, bluetooth, optical, usb, analogue, tv (6 inputs)
+- **LSX II LT**: wifi, bluetooth, optical, usb, tv (5 inputs)
+- **LS50 Wireless II**: wifi, bluetooth, optical, coaxial, analogue, tv (6 inputs)
+- **LS60 Wireless**: wifi, bluetooth, optical, coaxial, analogue, tv (6 inputs)
+- **XIO Soundbar**: wifi, bluetooth, optical, tv (4 inputs)
+
+#### Volume Behavior Settings
+
+Configure global volume limits and behavior:
+
 ```python
-# Standby timeout
-my_speaker.get_standby_mode()
-# (output example) >>> 'standbyOff'  # 'standbyOff', 'standby20m', 'standby60m'
-my_speaker.set_standby_mode('standby20m')
+# Get current volume settings
+settings = speaker.get_volume_settings()
+# Returns: {'max_volume': 100, 'step': 1, 'limit': 100, 'display': 'linear'}
 
-# Power-on chime
-my_speaker.get_startup_tone()
-# (output example) >>> True
-my_speaker.set_startup_tone(False)
+# Set maximum volume limit (safety feature for children/hearing protection)
+speaker.set_volume_settings(max_volume=80)  # Limit to 80%
 
-# HDMI auto-source switching
-my_speaker.get_auto_switch_hdmi()
-# (output example) >>> True
-my_speaker.set_auto_switch_hdmi(False)
+# Set volume step size (how much volume changes per button press)
+speaker.set_volume_settings(step=2)  # Change by 2% per step
 
-# Wired connection mode
-my_speaker.get_cable_mode()
-my_speaker.set_cable_mode('stereo')
+# Set volume limiter
+speaker.set_volume_settings(limit=75)  # Soft limit at 75%
 
-# Left/right master channel assignment
-my_speaker.get_master_channel()
-# (output example) >>> 'left'
-my_speaker.set_master_channel('right')
-
-# Which input source wakes the speaker from standby
-my_speaker.get_wake_source()
-my_speaker.set_wake_source('wifi')
-
-# Subwoofer and KW1 wireless sub auto-wake on startup
-my_speaker.get_subwoofer_wake_on_startup()
-my_speaker.set_subwoofer_wake_on_startup(True)
-my_speaker.get_kw1_wake_on_startup()
-my_speaker.set_kw1_wake_on_startup(True)
-
-# USB port charging
-my_speaker.get_usb_charging()
-my_speaker.set_usb_charging(True)
-
-# Fixed volume output level (for use with AV receivers)
-my_speaker.get_fixed_volume_mode()
-# (output example) >>> None  # None = disabled, integer = fixed level
-my_speaker.set_fixed_volume_mode(50)
-
-# Generic write method (counterpart to get_request)
-my_speaker.set_request('settings:/kef/host/speakerOn', 'activate', 'true')
+# Combine multiple settings
+speaker.set_volume_settings(max_volume=85, step=2, limit=80)
 ```
 
-**LED Controls**
+#### Reset Volume (Startup Volume)
+
+The "Reset Volume" feature (called "Startup Volume" in some contexts) controls what volume the speaker uses when waking from standby. This matches the KEF Connect app's "Reset volume" setting.
+
 ```python
-# Front logo LED
-my_speaker.get_front_led()
-# (output example) >>> True
-my_speaker.set_front_led(False)
+# Check if reset volume is enabled
+is_enabled = speaker.get_startup_volume_enabled()
+# Returns: True = enabled, False = disabled (resumes at last volume)
 
-# Standby indicator LED
-my_speaker.get_standby_led()
-my_speaker.set_standby_led(True)
+# Enable reset volume feature
+speaker.set_startup_volume_enabled(True)
 
-# Top touch panel (enable/disable)
-my_speaker.get_top_panel_enabled()
-my_speaker.set_top_panel_enabled(True)
-
-# Top panel LED in active state
-my_speaker.get_top_panel_led()
-my_speaker.set_top_panel_led(True)
-
-# Top panel LED in standby state
-my_speaker.get_top_panel_standby_led()
-my_speaker.set_top_panel_standby_led(False)
+# Disable reset volume (speaker resumes at last volume level)
+speaker.set_startup_volume_enabled(False)
 ```
+
+#### All Sources vs Individual Sources Mode
+
+When reset volume is enabled, choose between "All Sources" (global) or "Individual Sources" (per-input) mode:
+
+```python
+# Check current mode
+is_all_sources = speaker.get_standby_volume_behavior()
+# Returns: True = All Sources, False = Individual Sources
+
+# Set to "All Sources" mode (same reset volume for all inputs)
+speaker.set_standby_volume_behavior(True)
+
+# Set to "Individual Sources" mode (different reset volume per input)
+speaker.set_standby_volume_behavior(False)
+```
+
+**How it works:**
+- **All Sources (True)**: All inputs use the same reset volume (set via `defaultVolumeGlobal`)
+- **Individual Sources (False)**: Each input has its own reset volume (WiFi, Bluetooth, etc.)
+
+#### Async Support
+
+All volume management methods support async:
+
+```python
+import asyncio
+import pykefcontrol as pkf
+
+async def manage_volumes():
+    speaker = pkf.KefAsyncConnector('192.168.1.100')
+
+    # Get all volumes
+    volumes = await speaker.get_all_default_volumes()
+
+    # Set specific input volumes
+    await speaker.set_default_volume('wifi', 45)
+    await speaker.set_default_volume('bluetooth', 35)
+
+    # Configure volume settings
+    await speaker.set_volume_settings(max_volume=80, step=2)
+
+    # Enable reset volume with Individual Sources mode
+    await speaker.set_standby_volume_behavior(False)  # Individual Sources
+    await speaker.set_startup_volume_enabled(True)    # Enable reset volume
+
+asyncio.run(manage_volumes())
+```
+
+
+### System Behavior Settings
+
+Configure speaker power management, startup behavior, and inter-speaker connection settings.
+
+#### Auto-Standby Mode
+
+Control when the speaker automatically enters standby mode:
+
+```python
+import pykefcontrol as pkf
+
+speaker = pkf.KefConnector('192.168.1.100')
+
+# Get current standby mode
+mode = speaker.get_standby_mode()
+print(f"Current mode: {mode}")  # Returns 'standby_20mins'
+
+# Set standby mode
+speaker.set_standby_mode('standby_20mins')  # ECO mode (20 minutes)
+speaker.set_standby_mode('standby_30mins')  # 30 minutes
+speaker.set_standby_mode('standby_60mins')  # 60 minutes
+speaker.set_standby_mode('standby_none')    # Never auto-standby
+```
+
+**Standby Modes:**
+- `standby_20mins` - ECO mode (shown as "ECO" in KEF Connect app)
+- `standby_30mins` - 30 minutes auto-standby
+- `standby_60mins` - 60 minutes auto-standby
+- `standby_none` - Never auto-standby (manual standby only)
+
+#### Wake Source & HDMI Auto-Switch
+
+Configure which input wakes the speaker and HDMI auto-switching:
+
+```python
+# Set wake source (which input can wake speaker from standby)
+speaker.set_wake_source('wakeup_default')  # All inputs can wake
+speaker.set_wake_source('tv')              # Only TV/HDMI wakes
+speaker.set_wake_source('optical')         # Only optical wakes
+
+# Enable auto-switch to HDMI when signal detected
+speaker.set_auto_switch_hdmi(True)   # Auto-switch enabled
+speaker.set_auto_switch_hdmi(False)  # Manual input selection
+
+# Check current settings
+wake = speaker.get_wake_source()
+auto_hdmi = speaker.get_auto_switch_hdmi()
+print(f"Wake source: {wake}, Auto-HDMI: {auto_hdmi}")
+```
+
+#### Startup Behavior
+
+Control startup tone and USB charging:
+
+```python
+# Disable startup beep
+speaker.set_startup_tone(False)
+
+# Enable USB port charging
+speaker.set_usb_charging(True)
+
+# Check current settings
+tone = speaker.get_startup_tone()
+usb = speaker.get_usb_charging()
+```
+
+#### Inter-Speaker Connection
+
+Configure wired vs wireless connection between left/right speakers:
+
+```python
+# Set cable mode (for stereo pairs)
+speaker.set_cable_mode('wired')     # Use cable connection
+speaker.set_cable_mode('wireless')  # Use wireless connection
+
+# Set master channel designation
+speaker.set_master_channel('left')   # This is the left speaker
+speaker.set_master_channel('right')  # This is the right speaker
+
+# Get current settings
+cable = speaker.get_cable_mode()
+channel = speaker.get_master_channel()
+```
+
+#### Speaker Status
+
+Check if the speaker is powered on or in standby:
+
+```python
+status = speaker.get_speaker_status()
+if status == 'powerOn':
+    print("Speaker is powered on")
+elif status == 'standby':
+    print("Speaker is in standby mode")
+```
+
+#### Complete Configuration Example
+
+```python
+import pykefcontrol as pkf
+
+speaker = pkf.KefConnector('192.168.1.100')
+
+# Configure for home theater use
+speaker.set_standby_mode('standby_60mins')  # Long timeout
+speaker.set_wake_source('tv')                # Wake on TV signal
+speaker.set_auto_switch_hdmi(True)           # Auto-switch to HDMI
+speaker.set_startup_tone(False)              # Silent startup
+
+# Configure stereo pair
+speaker.set_cable_mode('wired')              # Use cable for better quality
+speaker.set_master_channel('left')           # Designate as left speaker
+```
+
+#### Async System Behavior
+
+All system behavior methods support async:
+
+```python
+import asyncio
+import pykefcontrol as pkf
+
+async def configure_speaker():
+    speaker = pkf.KefAsyncConnector('192.168.1.100')
+
+    # Get all settings
+    mode = await speaker.get_standby_mode()
+    wake = await speaker.get_wake_source()
+    status = await speaker.get_speaker_status()
+
+    print(f"Standby: {mode}, Wake: {wake}, Status: {status}")
+
+    # Configure settings
+    await speaker.set_standby_mode('standby_30mins')
+    await speaker.set_startup_tone(False)
+
+asyncio.run(configure_speaker())
+```
+
+
+### Do Not Disturb Settings
+
+Control LED indicators and startup behavior to minimize distractions. In the KEF Connect app, these appear under "Do Not Disturb" settings.
+
+**Important Note:** The API endpoints work on all KEF W2 platform speakers, but the physical effects vary by model:
+- **LSX II / LSX II LT / LS50 W2 / LS60**: Only standby LED and startup tone are exposed in KEF Connect app
+- **XIO Soundbar**: Full control panel LED controls (4 settings: control panel LED, control panel in standby, startup tone, control panel lock)
+
+#### Standby LED
+
+Control whether the LED indicator is visible when the speaker is in standby mode:
+
+```python
+import pykefcontrol as pkf
+
+speaker = pkf.KefConnector('192.168.1.100')
+
+# Enable standby LED (default)
+speaker.set_standby_led(True)
+
+# Disable standby LED (for dark rooms)
+speaker.set_standby_led(False)
+
+# Check current setting
+enabled = speaker.get_standby_led()
+print(f"Standby LED: {'On' if enabled else 'Off'}")
+```
+
+**Async version:**
+```python
+enabled = await speaker.get_standby_led()
+await speaker.set_standby_led(False)
+```
+
+#### Startup Tone
+
+Control the audible beep when powering on (also in System Behavior Settings):
+
+```python
+# Disable startup beep for silent power-on
+speaker.set_startup_tone(False)
+
+# Enable startup beep
+speaker.set_startup_tone(True)
+
+# Check current setting
+enabled = speaker.get_startup_tone()
+```
+
+#### XIO Soundbar: Control Panel LED Controls
+
+The XIO soundbar has exclusive control panel LED settings (4 controls shown in KEF Connect app under "Do Not Disturb"). The `set_top_panel_*` methods only work on XIO models.
+
+> **Note:** The `get/set_front_led()` methods exist for all models but have no visible effect on any currently tested speakers (LSX II, LSX II LT, XIO). The API field exists in firmware but appears to have no hardware implementation. These methods are kept for completeness in case future models support this feature.
+
+```python
+# Control panel LED during operation
+speaker.set_front_led(True)   # LED on during operation (default)
+speaker.set_front_led(False)  # LED off during operation
+
+# Control panel LED in standby
+speaker.set_top_panel_standby_led(True)   # LED on in standby
+speaker.set_top_panel_standby_led(False)  # LED off in standby
+
+# Enable/disable top panel entirely (control panel lock)
+speaker.set_top_panel_enabled(True)   # Panel active (default)
+speaker.set_top_panel_enabled(False)  # Panel locked/disabled
+
+# Check current settings
+front_led = speaker.get_front_led()
+panel_enabled = speaker.get_top_panel_enabled()
+standby_led = speaker.get_top_panel_standby_led()
+
+print(f"Front LED: {front_led}, Panel enabled: {panel_enabled}, Standby LED: {standby_led}")
+```
+
+**XIO Async version:**
+```python
+# XIO-specific async methods
+await speaker.set_front_led(False)
+await speaker.set_top_panel_standby_led(False)
+await speaker.set_top_panel_enabled(False)
+```
+
+#### Complete Do Not Disturb Configuration
+
+```python
+import pykefcontrol as pkf
+
+# Configure LSX II for bedroom use (minimal LEDs)
+lsx_speaker = pkf.KefConnector('192.168.1.100')  # LSX II
+lsx_speaker.set_standby_led(False)    # No standby indicator
+lsx_speaker.set_startup_tone(False)   # Silent power-on
+
+# Configure XIO for home theater (all LEDs off)
+xio_speaker = pkf.KefConnector('192.168.1.101')  # XIO Soundbar
+xio_speaker.set_standby_led(False)              # No standby LED
+xio_speaker.set_startup_tone(False)             # Silent power-on
+xio_speaker.set_front_led(False)                # Control panel off during operation
+xio_speaker.set_top_panel_standby_led(False)    # Control panel off in standby
+xio_speaker.set_top_panel_enabled(False)        # Lock control panel (optional)
+```
+
+
 
 #### Advanced features
 This function is used internally by pykefcontrol and returns a JSON output with a lot of information. You might want to use them to get extra information such as the artwork/album cover URL, which does not have a dedicated function _yet_ in pykefcontrol.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,111 @@ All the possible keys of the dictionary are:
  `source`, `song_status`, `volume`, `song_info`, `song_length`, `status`, `speaker_status`, `device_name`, `mute` and `other`.
 `other` contains some of the speaker-specific information that might have changed, but are not properties of either `KefConnector` or `KefAsyncConnector`. 
 
+**Volume Management**
+```python
+# Get default startup volume for a specific input source
+my_speaker.get_default_volume('wifi')
+# (output example) >>> 50
+
+# Set default startup volume for a specific input source
+# Supported sources: 'wifi', 'bluetooth', 'optical', 'coaxial', 'usb', 'analogue', 'tv'
+my_speaker.set_default_volume('wifi', 50)
+
+# Get default volumes for all input sources at once
+my_speaker.get_all_default_volumes()
+# (output example) >>> {'wifi': 50, 'bluetooth': 40, 'optical': 60, 'coaxial': 60, 'usb': 50, 'analogue': 60, 'tv': 50}
+
+# Get volume settings (max volume cap, step size, limit)
+my_speaker.get_volume_settings()
+# (output example) >>> {'max_volume': 100, 'step': 5, 'limit': 85}
+
+# Set volume settings
+my_speaker.set_volume_settings(max_volume=100, step=5, limit=85)
+
+# Get/set whether standby resumes at global or per-source volume
+my_speaker.get_standby_volume_behavior()
+# (output example) >>> True  # True = use global volume, False = use per-source volume
+my_speaker.set_standby_volume_behavior(True)
+
+# Get/set startup volume override (when enabled, uses configured default volumes on wake)
+my_speaker.get_startup_volume_enabled()
+# (output example) >>> False
+my_speaker.set_startup_volume_enabled(True)
+```
+
+**Hardware Settings**
+```python
+# Standby timeout
+my_speaker.get_standby_mode()
+# (output example) >>> 'standbyOff'  # 'standbyOff', 'standby20m', 'standby60m'
+my_speaker.set_standby_mode('standby20m')
+
+# Power-on chime
+my_speaker.get_startup_tone()
+# (output example) >>> True
+my_speaker.set_startup_tone(False)
+
+# HDMI auto-source switching
+my_speaker.get_auto_switch_hdmi()
+# (output example) >>> True
+my_speaker.set_auto_switch_hdmi(False)
+
+# Wired connection mode
+my_speaker.get_cable_mode()
+my_speaker.set_cable_mode('stereo')
+
+# Left/right master channel assignment
+my_speaker.get_master_channel()
+# (output example) >>> 'left'
+my_speaker.set_master_channel('right')
+
+# Which input source wakes the speaker from standby
+my_speaker.get_wake_source()
+my_speaker.set_wake_source('wifi')
+
+# Subwoofer and KW1 wireless sub auto-wake on startup
+my_speaker.get_subwoofer_wake_on_startup()
+my_speaker.set_subwoofer_wake_on_startup(True)
+my_speaker.get_kw1_wake_on_startup()
+my_speaker.set_kw1_wake_on_startup(True)
+
+# USB port charging
+my_speaker.get_usb_charging()
+my_speaker.set_usb_charging(True)
+
+# Fixed volume output level (for use with AV receivers)
+my_speaker.get_fixed_volume_mode()
+# (output example) >>> None  # None = disabled, integer = fixed level
+my_speaker.set_fixed_volume_mode(50)
+
+# Generic write method (counterpart to get_request)
+my_speaker.set_request('settings:/kef/host/speakerOn', 'activate', 'true')
+```
+
+**LED Controls**
+```python
+# Front logo LED
+my_speaker.get_front_led()
+# (output example) >>> True
+my_speaker.set_front_led(False)
+
+# Standby indicator LED
+my_speaker.get_standby_led()
+my_speaker.set_standby_led(True)
+
+# Top touch panel (enable/disable)
+my_speaker.get_top_panel_enabled()
+my_speaker.set_top_panel_enabled(True)
+
+# Top panel LED in active state
+my_speaker.get_top_panel_led()
+my_speaker.set_top_panel_led(True)
+
+# Top panel LED in standby state
+my_speaker.get_top_panel_standby_led()
+my_speaker.set_top_panel_standby_led(False)
+```
+
 #### Advanced features
 This function is used internally by pykefcontrol and returns a JSON output with a lot of information. You might want to use them to get extra information such as the artwork/album cover URL, which does not have a dedicated function _yet_ in pykefcontrol.
 

--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -7,7 +7,7 @@ import warnings
 
 
 _POST_MODELS = {"LS50WII", "LSXIILT", "LSXII", "LS60"}
-_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII"}
+_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII", "LS60Wireless": "LS60"}
 
 
 class KefConnector:

--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -87,6 +87,324 @@ class KefConnector:
         """
         self.volume = volume
 
+    def get_default_volume(self, input_source):
+        """Get default volume for a specific input source.
+
+        Args:
+            input_source (str): Input source name (wifi, bluetooth, optic, coaxial, usb, analog, tv)
+
+        Returns:
+            int: Volume level (0-100) for the specified input
+
+        Example:
+            volume = speaker.get_default_volume('wifi')  # Returns 50
+        """
+        # Map input source to API path
+        source_map = {
+            'wifi': 'Wifi',
+            'bluetooth': 'Bluetooth',
+            'optic': 'Optical',
+            'optical': 'Optical',
+            'coaxial': 'Coaxial',
+            'usb': 'USB',
+            'analog': 'Analogue',
+            'analogue': 'Analogue',
+            'tv': 'TV',
+            'hdmi': 'TV'
+        }
+
+        if input_source.lower() not in source_map:
+            raise ValueError(f"Invalid input source: {input_source}. Valid sources: {', '.join(source_map.keys())}")
+
+        api_source = source_map[input_source.lower()]
+        payload = {
+            "path": f"settings:/kef/host/defaultVolume{api_source}",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0]["i32_"]
+
+    def set_default_volume(self, input_source, volume):
+        """Set default volume for a specific input source.
+
+        Args:
+            input_source (str): Input source name (wifi, bluetooth, optic, coaxial, usb, analog, tv)
+            volume (int): Volume level (0-100)
+
+        Example:
+            speaker.set_default_volume('wifi', 50)
+            speaker.set_default_volume('bluetooth', 40)
+        """
+        if not 0 <= volume <= 100:
+            raise ValueError(f"Volume must be between 0 and 100, got {volume}")
+
+        # Map input source to API path
+        source_map = {
+            'global': 'Global',
+            'wifi': 'Wifi',
+            'bluetooth': 'Bluetooth',
+            'optic': 'Optical',
+            'optical': 'Optical',
+            'coaxial': 'Coaxial',
+            'usb': 'USB',
+            'analog': 'Analogue',
+            'analogue': 'Analogue',
+            'tv': 'TV',
+            'hdmi': 'TV'
+        }
+
+        if input_source.lower() not in source_map:
+            raise ValueError(f"Invalid input source: {input_source}. Valid sources: {', '.join(source_map.keys())}")
+
+        api_source = source_map[input_source.lower()]
+        payload = {
+            "path": f"settings:/kef/host/defaultVolume{api_source}",
+            "roles": "value",
+            "value": f'{{"type":"i32_","i32_":{volume}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_all_default_volumes(self):
+        """Get default volumes for all input sources on this speaker model.
+
+        Returns:
+            dict: Dictionary of input sources and their default volumes
+
+        Example:
+            volumes = speaker.get_all_default_volumes()
+            # Returns: {'global': 50, 'wifi': 45, 'bluetooth': 40, 'optical': 50, ...}
+        """
+        # Define all possible inputs
+        all_inputs = ['global', 'wifi', 'bluetooth', 'optical', 'coaxial', 'usb', 'analogue', 'tv']
+
+        # Map to API names
+        source_map = {
+            'global': 'Global',
+            'wifi': 'Wifi',
+            'bluetooth': 'Bluetooth',
+            'optical': 'Optical',
+            'coaxial': 'Coaxial',
+            'usb': 'USB',
+            'analogue': 'Analogue',
+            'tv': 'TV'
+        }
+
+        volumes = {}
+        for input_source in all_inputs:
+            try:
+                api_source = source_map[input_source]
+                payload = {
+                    "path": f"settings:/kef/host/defaultVolume{api_source}",
+                    "roles": "value",
+                }
+
+                with requests.get(
+                    "http://" + self.host + "/api/getData", params=payload
+                ) as response:
+                    if response.status_code == 200:
+                        json_output = response.json()
+                        volumes[input_source] = json_output[0]["i32_"]
+            except:
+                # Skip inputs that don't exist on this model
+                pass
+
+        return volumes
+
+    def get_volume_settings(self):
+        """Get volume behavior settings.
+
+        Returns:
+            dict: Volume settings including max_volume, step, limit, display mode
+
+        Example:
+            settings = speaker.get_volume_settings()
+            # Returns: {'max_volume': 100, 'step': 1, 'limit': 100, 'display': 'linear'}
+        """
+        settings = {}
+
+        # Get maximum volume
+        try:
+            payload = {"path": "settings:/kef/host/maximumVolume", "roles": "value"}
+            with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status_code == 200:
+                    settings['max_volume'] = response.json()[0]["i32_"]
+        except:
+            pass
+
+        # Get volume step (uses i16_ not i32_)
+        try:
+            payload = {"path": "settings:/kef/host/volumeStep", "roles": "value"}
+            with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status_code == 200:
+                    settings['step'] = response.json()[0]["i16_"]
+        except:
+            pass
+
+        # Get volume limit (is bool, not int)
+        try:
+            payload = {"path": "settings:/kef/host/volumeLimit", "roles": "value"}
+            with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status_code == 200:
+                    settings['limit_enabled'] = response.json()[0]["bool_"]
+        except:
+            pass
+
+        # Get volume display (XIO only)
+        try:
+            payload = {"path": "settings:/kef/host/volumeDisplay", "roles": "value"}
+            with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status_code == 200:
+                    settings['display'] = response.json()[0]["string_"]
+        except:
+            pass
+
+        return settings
+
+    def set_volume_settings(self, max_volume=None, step=None, limit=None):
+        """Set volume behavior settings.
+
+        Args:
+            max_volume (int, optional): Maximum volume (0-100)
+            step (int, optional): Volume increment step
+            limit (int, optional): Volume limiter (0-100)
+
+        Example:
+            speaker.set_volume_settings(max_volume=80, step=2)
+            speaker.set_volume_settings(limit=75)
+        """
+        if max_volume is not None:
+            if not 0 <= max_volume <= 100:
+                raise ValueError(f"max_volume must be between 0 and 100, got {max_volume}")
+            payload = {
+                "path": "settings:/kef/host/maximumVolume",
+                "roles": "value",
+                "value": f'{{"type":"i32_","i32_":{max_volume}}}',
+            }
+            with requests.get("http://" + self.host + "/api/setData", params=payload) as response:
+                pass
+
+        if step is not None:
+            if not 1 <= step <= 10:
+                raise ValueError(f"step must be between 1 and 10, got {step}")
+            payload = {
+                "path": "settings:/kef/host/volumeStep",
+                "roles": "value",
+                "value": f'{{"type":"i16_","i16_":{step}}}',
+            }
+            with requests.get("http://" + self.host + "/api/setData", params=payload) as response:
+                pass
+
+        if limit is not None:
+            payload = {
+                "path": "settings:/kef/host/volumeLimit",
+                "roles": "value",
+                "value": f'{{"type":"bool_","bool_":{str(limit).lower()}}}',
+            }
+            with requests.get("http://" + self.host + "/api/setData", params=payload) as response:
+                pass
+
+    def get_standby_volume_behavior(self):
+        """Get standby volume behavior setting.
+
+        Returns:
+            bool: True if using global volume mode, False if using per-input mode
+
+        Example:
+            is_global = speaker.get_standby_volume_behavior()
+        """
+        payload = {
+            "path": "settings:/kef/host/advancedStandbyDefaultVol",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        # advancedStandbyDefaultVol: false = global, true = per-input
+        return not json_output[0]["bool_"]
+
+    def set_standby_volume_behavior(self, use_global):
+        """Set standby volume behavior.
+
+        Args:
+            use_global (bool): True for global volume mode, False for per-input mode
+
+        Example:
+            speaker.set_standby_volume_behavior(True)  # Use global volume
+            speaker.set_standby_volume_behavior(False)  # Use per-input volumes
+        """
+        # advancedStandbyDefaultVol: false = global, true = per-input
+        payload = {
+            "path": "settings:/kef/host/advancedStandbyDefaultVol",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(not use_global).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_startup_volume_enabled(self):
+        """Get whether startup volume feature is enabled.
+
+        When enabled, the speaker uses configured startup volumes when waking from standby.
+        When disabled, the speaker resumes at the last volume level.
+
+        Returns:
+            bool: True if startup volume is enabled, False if disabled
+
+        Example:
+            is_enabled = speaker.get_startup_volume_enabled()
+        """
+        payload = {
+            "path": "settings:/kef/host/standbyDefaultVol",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0]["bool_"]
+
+    def set_startup_volume_enabled(self, enabled):
+        """Enable or disable the startup volume feature.
+
+        When enabled, the speaker uses configured startup volumes when waking from standby.
+        When disabled, the speaker resumes at the last volume level.
+
+        Args:
+            enabled (bool): True to enable startup volume, False to disable
+
+        Example:
+            speaker.set_startup_volume_enabled(True)   # Enable startup volume
+            speaker.set_startup_volume_enabled(False)  # Disable (resume at last volume)
+        """
+        payload = {
+            "path": "settings:/kef/host/standbyDefaultVol",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    # Network Diagnostics Methods (Phase 4)
     def _get_player_data(self):
         """
         Is the speaker currently playing
@@ -513,6 +831,717 @@ class KefConnector:
         return speaker_firmware_version
 
 
+    def get_auto_switch_hdmi(self):
+        """Get auto-switch to HDMI setting.
+
+        Returns:
+            bool: True if auto-switch enabled, False otherwise
+
+        Example:
+            enabled = speaker.get_auto_switch_hdmi()
+        """
+        payload = {
+            "path": "settings:/kef/host/autoSwitchToHDMI",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("bool_", False)
+
+    def set_auto_switch_hdmi(self, enabled):
+        """Set auto-switch to HDMI when signal detected.
+
+        Args:
+            enabled (bool): True to enable auto-switch, False to disable
+
+        Example:
+            speaker.set_auto_switch_hdmi(True)
+        """
+        payload = {
+            "path": "settings:/kef/host/autoSwitchToHDMI",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_standby_mode(self):
+        """Get auto-standby mode setting.
+
+        Returns:
+            str: Standby mode ('standby_20mins', 'standby_30mins', 'standby_60mins', 'standby_none')
+
+        Example:
+            mode = speaker.get_standby_mode()  # Returns 'standby_20mins' (ECO mode)
+        """
+        payload = {
+            "path": "settings:/kef/host/standbyMode",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("string_", "standby_20mins")
+
+    def set_standby_mode(self, mode):
+        """Set auto-standby mode.
+
+        Args:
+            mode (str): Standby mode - 'standby_20mins' (ECO), 'standby_30mins',
+                       'standby_60mins', or 'standby_none' (Never)
+
+        Example:
+            speaker.set_standby_mode('standby_20mins')  # ECO mode (20 minutes)
+            speaker.set_standby_mode('standby_none')     # Never auto-standby
+        """
+        valid_modes = ['standby_20mins', 'standby_30mins', 'standby_60mins', 'standby_none']
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid mode: {mode}. Valid modes: {', '.join(valid_modes)}")
+
+        payload = {
+            "path": "settings:/kef/host/standbyMode",
+            "roles": "value",
+            "value": f'{{"type":"string_","string_":"{mode}"}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_startup_tone(self):
+        """Get startup tone setting.
+
+        Returns:
+            bool: True if startup beep enabled, False otherwise
+
+        Example:
+            enabled = speaker.get_startup_tone()
+        """
+        payload = {
+            "path": "settings:/kef/host/startupTone",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("bool_", False)
+
+    def set_startup_tone(self, enabled):
+        """Set startup tone (power-on beep).
+
+        Args:
+            enabled (bool): True to enable startup beep, False to disable
+
+        Example:
+            speaker.set_startup_tone(False)  # Disable startup beep
+        """
+        payload = {
+            "path": "settings:/kef/host/startupTone",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_subwoofer_wake_on_startup(self):
+        """Get wake subwoofer on startup setting.
+
+        When enabled, the speaker will wake the subwoofer when it powers on.
+        This works with wired subwoofers.
+
+        Returns:
+            bool: True if wake subwoofer on startup is enabled
+        """
+        payload = {
+            "path": "settings:/kef/host/subwooferForceOn",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("bool_", False)
+
+    def set_subwoofer_wake_on_startup(self, enabled):
+        """Set wake subwoofer on startup.
+
+        When enabled, the speaker will wake the subwoofer when it powers on.
+        This works with wired subwoofers.
+
+        Args:
+            enabled (bool): True to enable wake subwoofer on startup
+
+        Example:
+            speaker.set_subwoofer_wake_on_startup(True)
+        """
+        payload = {
+            "path": "settings:/kef/host/subwooferForceOn",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_kw1_wake_on_startup(self):
+        """Get KW1 wake on startup setting.
+
+        When enabled, the speaker will wake a wireless subwoofer connected
+        via KW1 adapter when it powers on. This is specifically for
+        KC62/KF92 subwoofers with KW1 wireless adapter.
+
+        Returns:
+            bool: True if KW1 wake on startup is enabled
+        """
+        payload = {
+            "path": "settings:/kef/host/subwooferForceOnKW1",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("bool_", False)
+
+    def set_kw1_wake_on_startup(self, enabled):
+        """Set KW1 wake on startup.
+
+        When enabled, the speaker will wake a wireless subwoofer connected
+        via KW1 adapter when it powers on. This is specifically for
+        KC62/KF92 subwoofers with KW1 wireless adapter.
+
+        Args:
+            enabled (bool): True to enable KW1 wake on startup
+
+        Example:
+            speaker.set_kw1_wake_on_startup(True)
+        """
+        payload = {
+            "path": "settings:/kef/host/subwooferForceOnKW1",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_wake_source(self):
+        """Get wake-up source setting.
+
+        Returns:
+            str: Wake source ('wakeup_default', 'tv', 'wifi', 'bluetooth', 'optical')
+
+        Example:
+            source = speaker.get_wake_source()  # Returns 'wakeup_default'
+        """
+        payload = {
+            "path": "settings:/kef/host/wakeUpSource",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("kefWakeUpSource", "wakeup_default")
+
+    def set_wake_source(self, source):
+        """Set wake-up source.
+
+        Args:
+            source (str): Wake source - 'wakeup_default', 'tv', 'wifi', 'bluetooth', 'optical'
+
+        Example:
+            speaker.set_wake_source('tv')  # Wake on TV/HDMI signal
+        """
+        valid_sources = ['wakeup_default', 'tv', 'wifi', 'bluetooth', 'optical']
+        if source not in valid_sources:
+            raise ValueError(f"Invalid source: {source}. Valid sources: {', '.join(valid_sources)}")
+
+        payload = {
+            "path": "settings:/kef/host/wakeUpSource",
+            "roles": "value",
+            "value": f'{{"type":"kefWakeUpSource","kefWakeUpSource":"{source}"}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_usb_charging(self):
+        """Get USB charging setting.
+
+        Returns:
+            bool: True if USB charging enabled, False otherwise
+
+        Example:
+            enabled = speaker.get_usb_charging()
+        """
+        payload = {
+            "path": "settings:/kef/host/usbCharging",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("bool_", False)
+
+    def set_usb_charging(self, enabled):
+        """Set USB port charging.
+
+        Args:
+            enabled (bool): True to enable USB charging, False to disable
+
+        Example:
+            speaker.set_usb_charging(True)  # Enable USB charging
+        """
+        payload = {
+            "path": "settings:/kef/host/usbCharging",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_cable_mode(self):
+        """Get cable mode (wired/wireless inter-speaker connection).
+
+        Returns:
+            str: Cable mode ('wired' or 'wireless')
+
+        Example:
+            mode = speaker.get_cable_mode()  # Returns 'wired'
+        """
+        payload = {
+            "path": "settings:/kef/host/cableMode",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("string_", "wired")
+
+    def set_cable_mode(self, mode):
+        """Set cable mode for inter-speaker connection.
+
+        Args:
+            mode (str): Cable mode - 'wired' or 'wireless'
+
+        Example:
+            speaker.set_cable_mode('wireless')  # Use wireless connection
+        """
+        valid_modes = ['wired', 'wireless']
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid mode: {mode}. Valid modes: {', '.join(valid_modes)}")
+
+        payload = {
+            "path": "settings:/kef/host/cableMode",
+            "roles": "value",
+            "value": f'{{"type":"string_","string_":"{mode}"}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_master_channel(self):
+        """Get master channel (left/right speaker designation).
+
+        Returns:
+            str: Master channel ('left' or 'right')
+
+        Example:
+            channel = speaker.get_master_channel()  # Returns 'left'
+        """
+        payload = {
+            "path": "settings:/kef/host/masterChannelMode",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output[0].get("kefMasterChannelMode", "right")
+
+    def set_master_channel(self, channel):
+        """Set master channel designation.
+
+        Args:
+            channel (str): Master channel - 'left' or 'right'
+
+        Example:
+            speaker.set_master_channel('right')  # Set as right speaker
+        """
+        valid_channels = ['left', 'right']
+        if channel not in valid_channels:
+            raise ValueError(f"Invalid channel: {channel}. Valid channels: {', '.join(valid_channels)}")
+
+        payload = {
+            "path": "settings:/kef/host/masterChannelMode",
+            "roles": "value",
+            "value": f'{{"type":"kefMasterChannelMode","kefMasterChannelMode":"{channel}"}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+
+    def get_front_led(self):
+        """Get front panel LED setting.
+
+        Note: This API setting exists but has no visible effect on any
+        currently tested KEF speakers (LSX II, LSX II LT, XIO). The setting
+        may be reserved for future models or have no hardware implementation.
+
+        Returns:
+            bool: True if front LED is enabled, False if disabled
+
+        Example:
+            enabled = speaker.get_front_led()
+        """
+        payload = {
+            "path": "settings:/kef/host/disableFrontLED",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        # Note: API uses "disable" so we invert the boolean
+        return not json_output[0].get("bool_", False)
+
+    def set_front_led(self, enabled):
+        """Set front panel LED.
+
+        Note: This API setting exists but has no visible effect on any
+        currently tested KEF speakers (LSX II, LSX II LT, XIO). The setting
+        may be reserved for future models or have no hardware implementation.
+
+        Args:
+            enabled (bool): True to enable LED, False to disable
+
+        Example:
+            speaker.set_front_led(False)  # Disable front LED
+        """
+        # Note: API uses "disable" so we invert the boolean
+        disabled = not enabled
+        payload = {
+            "path": "settings:/kef/host/disableFrontLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(disabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_standby_led(self):
+        """Get standby LED setting.
+
+        Returns:
+            bool: True if standby LED is enabled, False if disabled
+
+        Example:
+            enabled = speaker.get_standby_led()
+        """
+        payload = {
+            "path": "settings:/kef/host/disableFrontStandbyLED",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        # Note: API uses "disable" so we invert the boolean
+        return not json_output[0].get("bool_", False)
+
+    def set_standby_led(self, enabled):
+        """Set standby LED.
+
+        Args:
+            enabled (bool): True to enable LED, False to disable
+
+        Example:
+            speaker.set_standby_led(True)  # Enable standby LED
+        """
+        # Note: API uses "disable" so we invert the boolean
+        disabled = not enabled
+        payload = {
+            "path": "settings:/kef/host/disableFrontStandbyLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(disabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_top_panel_enabled(self):
+        """Get top panel (touch controls) enabled setting.
+
+        Returns:
+            bool: True if top panel is enabled, False if disabled
+
+        Example:
+            enabled = speaker.get_top_panel_enabled()
+        """
+        payload = {
+            "path": "settings:/kef/host/disableTopPanel",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        # Note: API uses "disable" so we invert the boolean
+        return not json_output[0].get("bool_", False)
+
+    def set_top_panel_enabled(self, enabled):
+        """Set top panel (touch controls) enabled.
+
+        Args:
+            enabled (bool): True to enable top panel, False to disable
+
+        Example:
+            speaker.set_top_panel_enabled(False)  # Disable touch panel
+        """
+        # Note: API uses "disable" so we invert the boolean
+        disabled = not enabled
+        payload = {
+            "path": "settings:/kef/host/disableTopPanel",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(disabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_top_panel_led(self):
+        """Get top panel LED setting (XIO only).
+
+        Returns:
+            bool: True if enabled, False if disabled, None if not available (non-XIO speakers)
+
+        Example:
+            enabled = speaker.get_top_panel_led()  # XIO only
+            if enabled is not None:
+                print(f"Top panel LED: {'ON' if enabled else 'OFF'}")
+        """
+        payload = {
+            "path": "settings:/kef/host/topPanelLED",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+            # Check if response is an error (dict with 'error' key) or empty
+            if isinstance(json_output, dict) and 'error' in json_output:
+                return None
+            if json_output and len(json_output) > 0:
+                    return json_output[0].get("bool_", False)
+            return None
+
+    def set_top_panel_led(self, enabled):
+        """Set top panel LED (XIO only).
+
+        Args:
+            enabled (bool): True to enable LED, False to disable
+
+        Example:
+            speaker.set_top_panel_led(True)  # XIO only
+        """
+        payload = {
+            "path": "settings:/kef/host/topPanelLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    def get_top_panel_standby_led(self):
+        """Get top panel standby LED setting (XIO only).
+
+        Returns:
+            bool: True if enabled, False if disabled, None if not available (non-XIO speakers)
+
+        Example:
+            enabled = speaker.get_top_panel_standby_led()  # XIO only
+            if enabled is not None:
+                print(f"Top panel standby LED: {'ON' if enabled else 'OFF'}")
+        """
+        payload = {
+            "path": "settings:/kef/host/topPanelStandbyLED",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+            # Check if response is an error (dict with 'error' key) or empty
+            if isinstance(json_output, dict) and 'error' in json_output:
+                return None
+            if json_output and len(json_output) > 0:
+                    return json_output[0].get("bool_", False)
+            return None
+
+    def set_top_panel_standby_led(self, enabled):
+        """Set top panel standby LED (XIO only).
+
+        Args:
+            enabled (bool): True to enable LED, False to disable
+
+        Example:
+            speaker.set_top_panel_standby_led(False)  # XIO only
+        """
+        payload = {
+            "path": "settings:/kef/host/topPanelStandbyLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+    # ===== Remote Control Methods =====
+
+
+    def get_fixed_volume_mode(self):
+        """Get fixed volume mode setting.
+
+        Returns:
+            int or None: Fixed volume level (0-100), or None if disabled
+
+        Example:
+            volume = speaker.get_fixed_volume_mode()
+            if volume is not None:
+                print(f"Fixed volume: {volume}")
+            else:
+                print("Fixed volume mode disabled")
+        """
+        payload = {
+            "path": "settings:/kef/host/remote/userFixedVolume",
+            "roles": "value",
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = response.json()
+            value = json_output[0].get("i32_", -1)
+            return None if value < 0 else value
+
+    def set_fixed_volume_mode(self, volume):
+        """Set fixed volume mode (locks volume at specific level).
+
+        Args:
+            volume (int or None): Volume level to lock (0-100), or None to disable
+
+        Example:
+            speaker.set_fixed_volume_mode(50)    # Lock volume at 50%
+            speaker.set_fixed_volume_mode(None)  # Disable fixed volume mode
+        """
+        if volume is None:
+            volume = -1  # -1 disables fixed volume mode
+        elif not isinstance(volume, int) or volume < 0 or volume > 100:
+            raise ValueError("Volume must be between 0-100 or None to disable")
+
+        payload = {
+            "path": "settings:/kef/host/remote/userFixedVolume",
+            "roles": "value",
+            "value": f'{{"type":"i32_","i32_":{volume}}}',
+        }
+
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+
+    # Generic write method
+    def set_request(self, path, roles="value", value=None):
+        """Generic method to set data via any API path.
+
+        Args:
+            path: API path to set (e.g., "firmwareupdate:downloadNewUpdate")
+            roles: API roles parameter (default: "value", use "activate" for actions)
+            value: Optional value to set (can be JSON string or dict)
+
+        Returns:
+            JSON response from API
+        """
+        payload = {
+            "path": path,
+            "roles": roles,
+        }
+        if value is not None:
+            payload["value"] = value
+        with requests.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = response.json()
+
+        return json_output
+
+
 class KefAsyncConnector:
     def __init__(self, host, session=None, model=None):
         self.host = host
@@ -621,6 +1650,31 @@ class KefAsyncConnector:
         await self.resurect_session()
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+        return json_output
+
+    async def set_request(self, path, roles="value", value=None):
+        """Generic method to set data via any API path.
+
+        Args:
+            path: API path to set (e.g., "firmwareupdate:install")
+            roles: API roles parameter (default: "value")
+            value: Optional value to send (JSON string)
+
+        Returns:
+            JSON response from API
+        """
+        payload = {
+            "path": path,
+            "roles": roles,
+        }
+        if value is not None:
+            payload["value"] = value
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/setData", params=payload
         ) as response:
             json_output = await response.json()
 
@@ -991,3 +2045,724 @@ class KefAsyncConnector:
         raw_data = await self._get_speaker_firmware_version()
         speaker_firmware_version = raw_data.split("_")[1]
         return speaker_firmware_version
+
+    async def get_default_volume(self, input_source):
+        """Get default volume for a specific input source.
+
+        Args:
+            input_source (str): Input source name (wifi, bluetooth, optic, coaxial, usb, analog, tv)
+
+        Returns:
+            int: Volume level (0-100) for the specified input
+
+        Example:
+            volume = await speaker.get_default_volume('wifi')  # Returns 50
+        """
+        # Map input source to API path
+        source_map = {
+            'wifi': 'Wifi',
+            'bluetooth': 'Bluetooth',
+            'optic': 'Optical',
+            'optical': 'Optical',
+            'coaxial': 'Coaxial',
+            'usb': 'USB',
+            'analog': 'Analogue',
+            'analogue': 'Analogue',
+            'tv': 'TV',
+            'hdmi': 'TV'
+        }
+
+        if input_source.lower() not in source_map:
+            raise ValueError(f"Invalid input source: {input_source}. Valid sources: {', '.join(source_map.keys())}")
+
+        api_source = source_map[input_source.lower()]
+        payload = {
+            "path": f"settings:/kef/host/defaultVolume{api_source}",
+            "roles": "value",
+        }
+
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+        return json_output[0]["i32_"]
+
+    async def set_default_volume(self, input_source, volume):
+        """Set default volume for a specific input source.
+
+        Args:
+            input_source (str): Input source name (global, wifi, bluetooth, optic, coaxial, usb, analog, tv)
+            volume (int): Volume level (0-100)
+
+        Example:
+            await speaker.set_default_volume('global', 30)  # Set global startup volume
+            await speaker.set_default_volume('wifi', 50)
+            await speaker.set_default_volume('bluetooth', 40)
+        """
+        if not 0 <= volume <= 100:
+            raise ValueError(f"Volume must be between 0 and 100, got {volume}")
+
+        # Map input source to API path
+        source_map = {
+            'global': 'Global',
+            'wifi': 'Wifi',
+            'bluetooth': 'Bluetooth',
+            'optic': 'Optical',
+            'optical': 'Optical',
+            'coaxial': 'Coaxial',
+            'usb': 'USB',
+            'analog': 'Analogue',
+            'analogue': 'Analogue',
+            'tv': 'TV',
+            'hdmi': 'TV'
+        }
+
+        if input_source.lower() not in source_map:
+            raise ValueError(f"Invalid input source: {input_source}. Valid sources: {', '.join(source_map.keys())}")
+
+        api_source = source_map[input_source.lower()]
+        payload = {
+            "path": f"settings:/kef/host/defaultVolume{api_source}",
+            "roles": "value",
+            "value": f'{{"type":"i32_","i32_":{volume}}}',
+        }
+
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+    async def get_all_default_volumes(self):
+        """Get default volumes for all input sources on this speaker model.
+
+        Returns:
+            dict: Dictionary of input sources and their default volumes
+
+        Example:
+            volumes = await speaker.get_all_default_volumes()
+            # Returns: {'global': 50, 'wifi': 45, 'bluetooth': 40, 'optical': 50, ...}
+        """
+        # Define all possible inputs
+        all_inputs = ['global', 'wifi', 'bluetooth', 'optical', 'coaxial', 'usb', 'analogue', 'tv']
+
+        # Map to API names
+        source_map = {
+            'global': 'Global',
+            'wifi': 'Wifi',
+            'bluetooth': 'Bluetooth',
+            'optical': 'Optical',
+            'coaxial': 'Coaxial',
+            'usb': 'USB',
+            'analogue': 'Analogue',
+            'tv': 'TV'
+        }
+
+        volumes = {}
+        await self.resurect_session()
+
+        for input_source in all_inputs:
+            try:
+                api_source = source_map[input_source]
+                payload = {
+                    "path": f"settings:/kef/host/defaultVolume{api_source}",
+                    "roles": "value",
+                }
+
+                async with self._session.get(
+                    "http://" + self.host + "/api/getData", params=payload
+                ) as response:
+                    if response.status == 200:
+                        json_output = await response.json()
+                        volumes[input_source] = json_output[0]["i32_"]
+            except:
+                # Skip inputs that don't exist on this model
+                pass
+
+        return volumes
+
+    async def get_volume_settings(self):
+        """Get volume behavior settings.
+
+        Returns:
+            dict: Volume settings including max_volume, step, limit, display mode
+
+        Example:
+            settings = await speaker.get_volume_settings()
+            # Returns: {'max_volume': 100, 'step': 1, 'limit': 100, 'display': 'linear'}
+        """
+        settings = {}
+        await self.resurect_session()
+
+        # Get maximum volume
+        try:
+            payload = {"path": "settings:/kef/host/maximumVolume", "roles": "value"}
+            async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status == 200:
+                    json_output = await response.json()
+                    settings['max_volume'] = json_output[0]["i32_"]
+        except:
+            pass
+
+        # Get volume step (uses i16_ not i32_)
+        try:
+            payload = {"path": "settings:/kef/host/volumeStep", "roles": "value"}
+            async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status == 200:
+                    json_output = await response.json()
+                    settings['step'] = json_output[0]["i16_"]
+        except:
+            pass
+
+        # Get volume limit (is bool, not int)
+        try:
+            payload = {"path": "settings:/kef/host/volumeLimit", "roles": "value"}
+            async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status == 200:
+                    json_output = await response.json()
+                    settings['limit_enabled'] = json_output[0]["bool_"]
+        except:
+            pass
+
+        # Get volume display (XIO only)
+        try:
+            payload = {"path": "settings:/kef/host/volumeDisplay", "roles": "value"}
+            async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+                if response.status == 200:
+                    json_output = await response.json()
+                    settings['display'] = json_output[0]["string_"]
+        except:
+            pass
+
+        return settings
+
+    async def set_volume_settings(self, max_volume=None, step=None, limit=None):
+        """Set volume behavior settings.
+
+        Args:
+            max_volume (int, optional): Maximum volume (0-100)
+            step (int, optional): Volume increment step (1-10)
+            limit (bool, optional): Enable volume limiter
+
+        Example:
+            await speaker.set_volume_settings(max_volume=80, step=2)
+            await speaker.set_volume_settings(limit=True)
+        """
+        await self.resurect_session()
+
+        if max_volume is not None:
+            if not 0 <= max_volume <= 100:
+                raise ValueError(f"max_volume must be between 0 and 100, got {max_volume}")
+            payload = {
+                "path": "settings:/kef/host/maximumVolume",
+                "roles": "value",
+                "value": f'{{"type":"i32_","i32_":{max_volume}}}',
+            }
+            async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+                pass
+
+        if step is not None:
+            if not 1 <= step <= 10:
+                raise ValueError(f"step must be between 1 and 10, got {step}")
+            payload = {
+                "path": "settings:/kef/host/volumeStep",
+                "roles": "value",
+                "value": f'{{"type":"i16_","i16_":{step}}}',
+            }
+            async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+                pass
+
+        if limit is not None:
+            payload = {
+                "path": "settings:/kef/host/volumeLimit",
+                "roles": "value",
+                "value": f'{{"type":"bool_","bool_":{str(limit).lower()}}}',
+            }
+            async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+                pass
+
+    async def get_standby_volume_behavior(self):
+        """Get standby volume behavior setting.
+
+        Returns:
+            bool: True if using global volume mode (All sources), False if using per-input mode (Individual sources)
+
+        Example:
+            is_global = await speaker.get_standby_volume_behavior()
+        """
+        payload = {
+            "path": "settings:/kef/host/advancedStandbyDefaultVol",
+            "roles": "value",
+        }
+
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+        # advancedStandbyDefaultVol: false = global (All sources), true = per-input (Individual sources)
+        return not json_output[0]["bool_"]
+
+    async def set_standby_volume_behavior(self, use_global):
+        """Set standby volume behavior.
+
+        Args:
+            use_global (bool): True for global volume mode (All sources), False for per-input mode (Individual sources)
+
+        Example:
+            await speaker.set_standby_volume_behavior(True)  # All sources
+            await speaker.set_standby_volume_behavior(False)  # Individual sources
+        """
+        # advancedStandbyDefaultVol: false = global (All sources), true = per-input (Individual sources)
+        payload = {
+            "path": "settings:/kef/host/advancedStandbyDefaultVol",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(not use_global).lower()}}}',
+        }
+
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+    async def get_startup_volume_enabled(self):
+        """Get whether reset volume feature is enabled.
+
+        When enabled, the speaker uses configured reset volumes when waking from standby.
+        When disabled, the speaker resumes at the last volume level.
+
+        Returns:
+            bool: True if reset volume is enabled, False if disabled
+
+        Example:
+            is_enabled = await speaker.get_startup_volume_enabled()
+        """
+        payload = {
+            "path": "settings:/kef/host/standbyDefaultVol",
+            "roles": "value",
+        }
+
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/getData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+        return json_output[0]["bool_"]
+
+    async def set_startup_volume_enabled(self, enabled):
+        """Enable or disable the reset volume feature.
+
+        When enabled, the speaker uses configured reset volumes when waking from standby.
+        When disabled, the speaker resumes at the last volume level.
+
+        Args:
+            enabled (bool): True to enable reset volume, False to disable
+
+        Example:
+            await speaker.set_startup_volume_enabled(True)   # Enable reset volume
+            await speaker.set_startup_volume_enabled(False)  # Disable (resume at last volume)
+        """
+        payload = {
+            "path": "settings:/kef/host/standbyDefaultVol",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+
+        await self.resurect_session()
+        async with self._session.get(
+            "http://" + self.host + "/api/setData", params=payload
+        ) as response:
+            json_output = await response.json()
+
+    # Async Network Diagnostics Methods (Phase 4)
+
+    async def get_auto_switch_hdmi(self):
+        """Get auto-switch to HDMI setting."""
+        payload = {"path": "settings:/kef/host/autoSwitchToHDMI", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("bool_", False)
+
+    async def set_auto_switch_hdmi(self, enabled):
+        """Set auto-switch to HDMI when signal detected."""
+        payload = {
+            "path": "settings:/kef/host/autoSwitchToHDMI",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_standby_mode(self):
+        """Get auto-standby mode setting."""
+        payload = {"path": "settings:/kef/host/standbyMode", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("string_", "standby_20mins")
+
+    async def set_standby_mode(self, mode):
+        """Set auto-standby mode."""
+        valid_modes = ['standby_20mins', 'standby_30mins', 'standby_60mins', 'standby_none']
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid mode: {mode}. Valid modes: {', '.join(valid_modes)}")
+        payload = {
+            "path": "settings:/kef/host/standbyMode",
+            "roles": "value",
+            "value": f'{{"type":"string_","string_":"{mode}"}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_startup_tone(self):
+        """Get startup tone setting."""
+        payload = {"path": "settings:/kef/host/startupTone", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("bool_", False)
+
+    async def set_startup_tone(self, enabled):
+        """Set startup tone (power-on beep)."""
+        payload = {
+            "path": "settings:/kef/host/startupTone",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_subwoofer_wake_on_startup(self):
+        """Get wake subwoofer on startup setting.
+
+        When enabled, the speaker will wake the subwoofer when it powers on.
+        This works with wired subwoofers.
+
+        Returns:
+            bool: True if wake subwoofer on startup is enabled
+        """
+        payload = {"path": "settings:/kef/host/subwooferForceOn", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("bool_", False)
+
+    async def set_subwoofer_wake_on_startup(self, enabled):
+        """Set wake subwoofer on startup.
+
+        When enabled, the speaker will wake the subwoofer when it powers on.
+        This works with wired subwoofers.
+
+        Args:
+            enabled (bool): True to enable wake subwoofer on startup
+        """
+        payload = {
+            "path": "settings:/kef/host/subwooferForceOn",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_kw1_wake_on_startup(self):
+        """Get KW1 wake on startup setting.
+
+        When enabled, the speaker will wake a wireless subwoofer connected
+        via KW1 adapter when it powers on. This is specifically for
+        KC62/KF92 subwoofers with KW1 wireless adapter.
+
+        Returns:
+            bool: True if KW1 wake on startup is enabled
+        """
+        payload = {"path": "settings:/kef/host/subwooferForceOnKW1", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("bool_", False)
+
+    async def set_kw1_wake_on_startup(self, enabled):
+        """Set KW1 wake on startup.
+
+        When enabled, the speaker will wake a wireless subwoofer connected
+        via KW1 adapter when it powers on. This is specifically for
+        KC62/KF92 subwoofers with KW1 wireless adapter.
+
+        Args:
+            enabled (bool): True to enable KW1 wake on startup
+        """
+        payload = {
+            "path": "settings:/kef/host/subwooferForceOnKW1",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_wake_source(self):
+        """Get wake-up source setting."""
+        payload = {"path": "settings:/kef/host/wakeUpSource", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("kefWakeUpSource", "wakeup_default")
+
+    async def set_wake_source(self, source):
+        """Set wake-up source."""
+        valid_sources = ['wakeup_default', 'tv', 'wifi', 'bluetooth', 'optical']
+        if source not in valid_sources:
+            raise ValueError(f"Invalid source: {source}. Valid sources: {', '.join(valid_sources)}")
+        payload = {
+            "path": "settings:/kef/host/wakeUpSource",
+            "roles": "value",
+            "value": f'{{"type":"kefWakeUpSource","kefWakeUpSource":"{source}"}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_usb_charging(self):
+        """Get USB charging setting."""
+        payload = {"path": "settings:/kef/host/usbCharging", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("bool_", False)
+
+    async def set_usb_charging(self, enabled):
+        """Set USB port charging."""
+        payload = {
+            "path": "settings:/kef/host/usbCharging",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_cable_mode(self):
+        """Get cable mode (wired/wireless inter-speaker connection)."""
+        payload = {"path": "settings:/kef/host/cableMode", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("string_", "wired")
+
+    async def set_cable_mode(self, mode):
+        """Set cable mode for inter-speaker connection."""
+        valid_modes = ['wired', 'wireless']
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid mode: {mode}. Valid modes: {', '.join(valid_modes)}")
+        payload = {
+            "path": "settings:/kef/host/cableMode",
+            "roles": "value",
+            "value": f'{{"type":"string_","string_":"{mode}"}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_master_channel(self):
+        """Get master channel (left/right speaker designation)."""
+        payload = {"path": "settings:/kef/host/masterChannelMode", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return json_output[0].get("kefMasterChannelMode", "right")
+
+    async def set_master_channel(self, channel):
+        """Set master channel designation."""
+        valid_channels = ['left', 'right']
+        if channel not in valid_channels:
+            raise ValueError(f"Invalid channel: {channel}. Valid channels: {', '.join(valid_channels)}")
+        payload = {
+            "path": "settings:/kef/host/masterChannelMode",
+            "roles": "value",
+            "value": f'{{"type":"kefMasterChannelMode","kefMasterChannelMode":"{channel}"}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+
+    async def get_front_led(self):
+        """Get front panel LED setting.
+
+        Note: This API setting exists but has no visible effect on any
+        currently tested KEF speakers (LSX II, LSX II LT, XIO).
+        """
+        payload = {"path": "settings:/kef/host/disableFrontLED", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return not json_output[0].get("bool_", False)
+
+    async def set_front_led(self, enabled):
+        """Set front panel LED.
+
+        Note: This API setting exists but has no visible effect on any
+        currently tested KEF speakers (LSX II, LSX II LT, XIO).
+        """
+        disabled = not enabled
+        payload = {
+            "path": "settings:/kef/host/disableFrontLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(disabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_standby_led(self):
+        """Get standby LED setting."""
+        payload = {"path": "settings:/kef/host/disableFrontStandbyLED", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return not json_output[0].get("bool_", False)
+
+    async def set_standby_led(self, enabled):
+        """Set standby LED."""
+        disabled = not enabled
+        payload = {
+            "path": "settings:/kef/host/disableFrontStandbyLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(disabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_top_panel_enabled(self):
+        """Get top panel (touch controls) enabled setting."""
+        payload = {"path": "settings:/kef/host/disableTopPanel", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        return not json_output[0].get("bool_", False)
+
+    async def set_top_panel_enabled(self, enabled):
+        """Set top panel (touch controls) enabled."""
+        disabled = not enabled
+        payload = {
+            "path": "settings:/kef/host/disableTopPanel",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(disabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_top_panel_led(self):
+        """Get top panel LED setting (XIO only).
+
+        Returns:
+            bool: True if enabled, False if disabled, None if not available (non-XIO speakers)
+        """
+        payload = {"path": "settings:/kef/host/topPanelLED", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+            # Check if response is an error (dict with 'error' key) or empty
+            if isinstance(json_output, dict) and 'error' in json_output:
+                return None
+            if json_output and len(json_output) > 0:
+                return json_output[0].get("bool_", False)
+        return None
+
+    async def set_top_panel_led(self, enabled):
+        """Set top panel LED (XIO only)."""
+        payload = {
+            "path": "settings:/kef/host/topPanelLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    async def get_top_panel_standby_led(self):
+        """Get top panel standby LED setting (XIO only).
+
+        Returns:
+            bool: True if enabled, False if disabled, None if not available (non-XIO speakers)
+        """
+        payload = {"path": "settings:/kef/host/topPanelStandbyLED", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+            # Check if response is an error (dict with 'error' key) or empty
+            if isinstance(json_output, dict) and 'error' in json_output:
+                return None
+            if json_output and len(json_output) > 0:
+                return json_output[0].get("bool_", False)
+        return None
+
+    async def set_top_panel_standby_led(self, enabled):
+        """Set top panel standby LED (XIO only)."""
+        payload = {
+            "path": "settings:/kef/host/topPanelStandbyLED",
+            "roles": "value",
+            "value": f'{{"type":"bool_","bool_":{str(enabled).lower()}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+
+    # ===== Remote Control Methods (Async) =====
+
+
+    async def get_fixed_volume_mode(self):
+        """Get fixed volume mode setting.
+
+        Returns:
+            int or None: Fixed volume level (0-100), or None if disabled
+
+        Example:
+            volume = await speaker.get_fixed_volume_mode()
+            if volume is not None:
+                print(f"Fixed volume: {volume}")
+            else:
+                print("Fixed volume mode disabled")
+        """
+        payload = {"path": "settings:/kef/host/remote/userFixedVolume", "roles": "value"}
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            json_output = await response.json()
+        value = json_output[0].get("i32_", -1)
+        return None if value < 0 else value
+
+    async def set_fixed_volume_mode(self, volume):
+        """Set fixed volume mode (locks volume at specific level).
+
+        Args:
+            volume (int or None): Volume level to lock (0-100), or None to disable
+
+        Example:
+            await speaker.set_fixed_volume_mode(50)    # Lock volume at 50%
+            await speaker.set_fixed_volume_mode(None)  # Disable fixed volume mode
+        """
+        if volume is None:
+            volume = -1  # -1 disables fixed volume mode
+        elif not isinstance(volume, int) or volume < 0 or volume > 100:
+            raise ValueError("Volume must be between 0-100 or None to disable")
+
+        payload = {
+            "path": "settings:/kef/host/remote/userFixedVolume",
+            "roles": "value",
+            "value": f'{{"type":"i32_","i32_":{volume}}}',
+        }
+        await self.resurect_session()
+        async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            json_output = await response.json()
+

--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -60,6 +60,7 @@ class KefConnector:
             with requests.post(
                 "http://" + self.host + "/api/setData", json=payload
             ) as response:
+                response.raise_for_status()
                 return response.json()
         else:
             payload = dict(payload)
@@ -67,6 +68,7 @@ class KefConnector:
             with requests.get(
                 "http://" + self.host + "/api/setData", params=payload
             ) as response:
+                response.raise_for_status()
                 return response.json()
 
     def _track_control(self, command):
@@ -125,6 +127,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["i32_"]
@@ -171,6 +174,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_all_default_volumes(self):
@@ -211,6 +215,7 @@ class KefConnector:
                     "http://" + self.host + "/api/getData", params=payload
                 ) as response:
                     if response.status_code == 200:
+                        response.raise_for_status()
                         json_output = response.json()
                         volumes[input_source] = json_output[0]["i32_"]
             except:
@@ -236,6 +241,7 @@ class KefConnector:
             payload = {"path": "settings:/kef/host/maximumVolume", "roles": "value"}
             with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status_code == 200:
+                    response.raise_for_status()
                     settings['max_volume'] = response.json()[0]["i32_"]
         except:
             pass
@@ -245,6 +251,7 @@ class KefConnector:
             payload = {"path": "settings:/kef/host/volumeStep", "roles": "value"}
             with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status_code == 200:
+                    response.raise_for_status()
                     settings['step'] = response.json()[0]["i16_"]
         except:
             pass
@@ -254,6 +261,7 @@ class KefConnector:
             payload = {"path": "settings:/kef/host/volumeLimit", "roles": "value"}
             with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status_code == 200:
+                    response.raise_for_status()
                     settings['limit_enabled'] = response.json()[0]["bool_"]
         except:
             pass
@@ -263,6 +271,7 @@ class KefConnector:
             payload = {"path": "settings:/kef/host/volumeDisplay", "roles": "value"}
             with requests.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status_code == 200:
+                    response.raise_for_status()
                     settings['display'] = response.json()[0]["string_"]
         except:
             pass
@@ -329,6 +338,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         # advancedStandbyDefaultVol: false = global, true = per-input
@@ -354,6 +364,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_startup_volume_enabled(self):
@@ -376,6 +387,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["bool_"]
@@ -402,6 +414,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     # Network Diagnostics Methods (Phase 4)
@@ -417,6 +430,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]
@@ -500,6 +514,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output
@@ -568,6 +583,7 @@ class KefConnector:
         with requests.post(
             "http://" + self.host + "/api/event/modifyQueue", json=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         # Update polling_queue property with queue uuid
@@ -640,6 +656,7 @@ class KefConnector:
             params=payload,
             timeout=timeout + 0.5,  # add 0.5 seconds to timeout to allow for processing
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         # Process all events
@@ -666,6 +683,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["string_"]
@@ -678,6 +696,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["string_"]
@@ -690,6 +709,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["kefSpeakerStatus"]
@@ -718,6 +738,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["kefPhysicalSource"]
@@ -749,6 +770,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["i32_"]
@@ -793,6 +815,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["i64_"]
@@ -810,6 +833,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0]["string_"]
@@ -848,6 +872,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("bool_", False)
@@ -870,6 +895,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_standby_mode(self):
@@ -889,6 +915,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("string_", "standby_20mins")
@@ -917,6 +944,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_startup_tone(self):
@@ -936,6 +964,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("bool_", False)
@@ -958,6 +987,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_subwoofer_wake_on_startup(self):
@@ -977,6 +1007,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("bool_", False)
@@ -1002,6 +1033,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_kw1_wake_on_startup(self):
@@ -1022,6 +1054,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("bool_", False)
@@ -1048,6 +1081,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_wake_source(self):
@@ -1067,6 +1101,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("kefWakeUpSource", "wakeup_default")
@@ -1093,6 +1128,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_usb_charging(self):
@@ -1112,6 +1148,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("bool_", False)
@@ -1134,6 +1171,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_cable_mode(self):
@@ -1153,6 +1191,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("string_", "wired")
@@ -1179,6 +1218,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_master_channel(self):
@@ -1198,6 +1238,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output[0].get("kefMasterChannelMode", "right")
@@ -1224,6 +1265,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
 
@@ -1248,6 +1290,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         # Note: API uses "disable" so we invert the boolean
@@ -1277,6 +1320,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_standby_led(self):
@@ -1296,6 +1340,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         # Note: API uses "disable" so we invert the boolean
@@ -1321,6 +1366,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_top_panel_enabled(self):
@@ -1340,6 +1386,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         # Note: API uses "disable" so we invert the boolean
@@ -1365,6 +1412,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_top_panel_led(self):
@@ -1386,6 +1434,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
             # Check if response is an error (dict with 'error' key) or empty
             if isinstance(json_output, dict) and 'error' in json_output:
@@ -1412,6 +1461,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     def get_top_panel_standby_led(self):
@@ -1433,6 +1483,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
             # Check if response is an error (dict with 'error' key) or empty
             if isinstance(json_output, dict) and 'error' in json_output:
@@ -1459,6 +1510,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
     # ===== Remote Control Methods =====
@@ -1485,6 +1537,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
             value = json_output[0].get("i32_", -1)
             return None if value < 0 else value
@@ -1513,6 +1566,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
 
@@ -1537,6 +1591,7 @@ class KefConnector:
         with requests.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = response.json()
 
         return json_output
@@ -1601,6 +1656,7 @@ class KefAsyncConnector:
             async with self._session.post(
                 "http://" + self.host + "/api/setData", json=payload
             ) as response:
+                response.raise_for_status()
                 return await response.json()
         else:
             payload = dict(payload)
@@ -1608,6 +1664,7 @@ class KefAsyncConnector:
             async with self._session.get(
                 "http://" + self.host + "/api/setData", params=payload
             ) as response:
+                response.raise_for_status()
                 return await response.json()
 
     async def _track_control(self, command):
@@ -1629,6 +1686,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]
@@ -1651,6 +1709,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output
@@ -1676,6 +1735,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output
@@ -1830,6 +1890,7 @@ class KefAsyncConnector:
         async with self._session.post(
             "http://" + self.host + "/api/event/modifyQueue", json=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         # Update polling_queue property with queue uuid
@@ -1899,6 +1960,7 @@ class KefAsyncConnector:
             params=payload,
             timeout=10 + 0.5,  # add 0.5 seconds to timeout to allow for processing
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         # Process all events
@@ -1924,6 +1986,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["string_"]
@@ -1936,6 +1999,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["string_"]
@@ -1948,6 +2012,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["kefSpeakerStatus"]
@@ -1978,6 +2043,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["i64_"]
@@ -1994,6 +2060,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["kefPhysicalSource"]
@@ -2009,6 +2076,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["i32_"]
@@ -2026,6 +2094,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["string_"]
@@ -2085,6 +2154,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["i32_"]
@@ -2133,6 +2203,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_all_default_volumes(self):
@@ -2175,6 +2246,7 @@ class KefAsyncConnector:
                     "http://" + self.host + "/api/getData", params=payload
                 ) as response:
                     if response.status == 200:
+                        response.raise_for_status()
                         json_output = await response.json()
                         volumes[input_source] = json_output[0]["i32_"]
             except:
@@ -2201,6 +2273,7 @@ class KefAsyncConnector:
             payload = {"path": "settings:/kef/host/maximumVolume", "roles": "value"}
             async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status == 200:
+                    response.raise_for_status()
                     json_output = await response.json()
                     settings['max_volume'] = json_output[0]["i32_"]
         except:
@@ -2211,6 +2284,7 @@ class KefAsyncConnector:
             payload = {"path": "settings:/kef/host/volumeStep", "roles": "value"}
             async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status == 200:
+                    response.raise_for_status()
                     json_output = await response.json()
                     settings['step'] = json_output[0]["i16_"]
         except:
@@ -2221,6 +2295,7 @@ class KefAsyncConnector:
             payload = {"path": "settings:/kef/host/volumeLimit", "roles": "value"}
             async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status == 200:
+                    response.raise_for_status()
                     json_output = await response.json()
                     settings['limit_enabled'] = json_output[0]["bool_"]
         except:
@@ -2231,6 +2306,7 @@ class KefAsyncConnector:
             payload = {"path": "settings:/kef/host/volumeDisplay", "roles": "value"}
             async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
                 if response.status == 200:
+                    response.raise_for_status()
                     json_output = await response.json()
                     settings['display'] = json_output[0]["string_"]
         except:
@@ -2301,6 +2377,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         # advancedStandbyDefaultVol: false = global (All sources), true = per-input (Individual sources)
@@ -2327,6 +2404,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_startup_volume_enabled(self):
@@ -2350,6 +2428,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/getData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
         return json_output[0]["bool_"]
@@ -2377,6 +2456,7 @@ class KefAsyncConnector:
         async with self._session.get(
             "http://" + self.host + "/api/setData", params=payload
         ) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     # Async Network Diagnostics Methods (Phase 4)
@@ -2386,6 +2466,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/autoSwitchToHDMI", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("bool_", False)
 
@@ -2398,6 +2479,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_standby_mode(self):
@@ -2405,6 +2487,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/standbyMode", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("string_", "standby_20mins")
 
@@ -2420,6 +2503,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_startup_tone(self):
@@ -2427,6 +2511,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/startupTone", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("bool_", False)
 
@@ -2439,6 +2524,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_subwoofer_wake_on_startup(self):
@@ -2453,6 +2539,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/subwooferForceOn", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("bool_", False)
 
@@ -2472,6 +2559,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_kw1_wake_on_startup(self):
@@ -2487,6 +2575,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/subwooferForceOnKW1", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("bool_", False)
 
@@ -2507,6 +2596,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_wake_source(self):
@@ -2514,6 +2604,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/wakeUpSource", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("kefWakeUpSource", "wakeup_default")
 
@@ -2529,6 +2620,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_usb_charging(self):
@@ -2536,6 +2628,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/usbCharging", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("bool_", False)
 
@@ -2548,6 +2641,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_cable_mode(self):
@@ -2555,6 +2649,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/cableMode", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("string_", "wired")
 
@@ -2570,6 +2665,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_master_channel(self):
@@ -2577,6 +2673,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/masterChannelMode", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return json_output[0].get("kefMasterChannelMode", "right")
 
@@ -2592,6 +2689,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
 
@@ -2604,6 +2702,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/disableFrontLED", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return not json_output[0].get("bool_", False)
 
@@ -2621,6 +2720,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_standby_led(self):
@@ -2628,6 +2728,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/disableFrontStandbyLED", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return not json_output[0].get("bool_", False)
 
@@ -2641,6 +2742,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_top_panel_enabled(self):
@@ -2648,6 +2750,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/disableTopPanel", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         return not json_output[0].get("bool_", False)
 
@@ -2661,6 +2764,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_top_panel_led(self):
@@ -2672,6 +2776,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/topPanelLED", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
             # Check if response is an error (dict with 'error' key) or empty
             if isinstance(json_output, dict) and 'error' in json_output:
@@ -2689,6 +2794,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     async def get_top_panel_standby_led(self):
@@ -2700,6 +2806,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/topPanelStandbyLED", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
             # Check if response is an error (dict with 'error' key) or empty
             if isinstance(json_output, dict) and 'error' in json_output:
@@ -2717,6 +2824,7 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 
     # ===== Remote Control Methods (Async) =====
@@ -2738,6 +2846,7 @@ class KefAsyncConnector:
         payload = {"path": "settings:/kef/host/remote/userFixedVolume", "roles": "value"}
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/getData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
         value = json_output[0].get("i32_", -1)
         return None if value < 0 else value
@@ -2764,5 +2873,6 @@ class KefAsyncConnector:
         }
         await self.resurect_session()
         async with self._session.get("http://" + self.host + "/api/setData", params=payload) as response:
+            response.raise_for_status()
             json_output = await response.json()
 

--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -6,8 +6,8 @@ import time
 import warnings
 
 
-_POST_MODELS = {"LS50WII", "LSXIILT", "LSXII", "LS60"}
-_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII", "LS60Wireless": "LS60"}
+_POST_MODELS = {"LS50WII", "LSXIILT", "LSXII", "LS60W", "XIO"}
+_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII", "LS60": "LS60W", "LS60Wireless": "LS60W"}
 
 
 class KefConnector:


### PR DESCRIPTION
This PR adds 48 new methods (24 sync + 24 async) covering three related areas of speaker configuration that are currently missing from the library. All methods have been tested on LSX II, LSX II LT, and XIO hardware.

## Volume Management (9 sync + 9 async)

Per-source default volumes and global volume settings:

- `get_default_volume(input_source)` / `set_default_volume(input_source, volume)` — per-source startup volume (wifi, bluetooth, optical, coaxial, usb, analogue, tv)
- `get_all_default_volumes()` — retrieve default volumes for all sources at once
- `get_volume_settings()` / `set_volume_settings(max_volume, step, limit)` — max volume cap, step size, and limit
- `get_standby_volume_behavior()` / `set_standby_volume_behavior(use_global)` — whether standby resumes at global or per-source volume
- `get_startup_volume_enabled()` / `set_startup_volume_enabled(enabled)` — startup volume override

## Hardware Settings (11 sync + 11 async)

Speaker behaviour and connectivity settings:

- `get_standby_mode()` / `set_standby_mode(mode)` — standby timeout (off/20min/60min)
- `get_startup_tone()` / `set_startup_tone(enabled)` — power-on chime
- `get_auto_switch_hdmi()` / `set_auto_switch_hdmi(enabled)` — HDMI auto-source switching
- `get_cable_mode()` / `set_cable_mode(mode)` — wired connection mode
- `get_master_channel()` / `set_master_channel(channel)` — left/right master assignment
- `get_wake_source()` / `set_wake_source(source)` — which input wakes the speaker
- `get_subwoofer_wake_on_startup()` / `set_subwoofer_wake_on_startup(enabled)` — subwoofer auto-wake
- `get_kw1_wake_on_startup()` / `set_kw1_wake_on_startup(enabled)` — KW1 wireless sub auto-wake
- `get_usb_charging()` / `set_usb_charging(enabled)` — USB port charging
- `get_fixed_volume_mode()` / `set_fixed_volume_mode(volume)` — fixed output level for AV receivers
- `set_request(path, roles, value)` — generic write counterpart to the existing `get_request()`

## LED Controls (5 sync + 5 async)

Visual indicator management:

- `get_front_led()` / `set_front_led(enabled)` — front logo LED
- `get_standby_led()` / `set_standby_led(enabled)` — standby indicator LED
- `get_top_panel_enabled()` / `set_top_panel_enabled(enabled)` — top touch panel
- `get_top_panel_led()` / `set_top_panel_led(enabled)` — top panel LED in active state
- `get_top_panel_standby_led()` / `set_top_panel_standby_led(enabled)` — top panel LED in standby

## Notes

- All methods follow the same pattern as existing code (sync uses `requests`, async uses `aiohttp`)
- Input validation and clear error messages included throughout
- `set_request()` mirrors the existing `get_request()` signature for consistency

## What's Coming Next

This is the first in a series of focused PRs. The full set of new endpoints was discovered by decompiling the KEF Connect Android APK (v1.26.1) using JADX, which gave us a definitive list of all 209 KEF API paths from `ApiPath.java`. Subsequent PRs will cover:

- **EQ & DSP** — `get_eq_profile` / `set_eq_profile`, desk mode, wall mode, bass extension, treble, balance, phase correction
- **XIO features** — room calibration, BLE subwoofer firmware updates, dialogue mode, sound profiles
- **Device information** — serial number, hardware version, KEF ID, full device info
- **Firmware updates** — check, download, and install speaker firmware
- **Network diagnostics** — internet ping, speed test, network stability
- **Privacy & streaming** — analytics settings, streaming quality, UI language
- **Alerts & timers** — alarm sounds, sleep timers

The goal is to eventually have complete API coverage in pykefcontrol, which will enable a much richer hass-kef-connector integration with full speaker configuration from Home Assistant.