### PR TITLE
Fix LSXII FW3.0 support

### DIFF
--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -6,8 +6,8 @@ import time
 import warnings
 
 
-_POST_MODELS = {"LS50WII", "LSXIILT"}
-_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT"}
+_POST_MODELS = {"LS50WII", "LSXIILT", "LSXII"}
+_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII"}
 
 
 class KefConnector:


### PR DESCRIPTION
KEF has released the 3.0 firmware for the LSX II, so your fix is now applied for LSX II.
https://assets.kef.com/pm/pm_firmware/release_notes.html#lsxii