### PR TITLE
Add XIO and LS60W POST support, LS60/LS60Wireless aliases

### DIFF
--- a/pykefcontrol/kef_connector.py
+++ b/pykefcontrol/kef_connector.py
@@ -6,8 +6,8 @@ import time
 import warnings
 
 
-_POST_MODELS = {"LS50WII", "LSXIILT", "LSXII", "LS60"}
-_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII"}
+_POST_MODELS = {"LS50WII", "LSXIILT", "LSXII", "LS60W", "XIO"}
+_MODEL_ALIASES = {"LS50W2": "LS50WII", "LSX2LT": "LSXIILT", "LSX2": "LSXII", "LS60": "LS60W", "LS60Wireless": "LS60W"}
 
 
 class KefConnector:


### PR DESCRIPTION
## Summary
- `XIO` firmware 1.4.135 switched `setData` from GET to POST — adds `"XIO"` to `_POST_MODELS`
- LS60 firmware renamed the model ID from `"LS60"` to `"LS60W"` (fixes #18) — replaces `"LS60"` with `"LS60W"` in `_POST_MODELS`
- Adds `"LS60": "LS60W"` alias for backward compat with users on older LS60 firmware
- Adds `"LS60Wireless": "LS60W"` alias for integrations that use the product name as the model key

Verified on XIO fw1.4.135.